### PR TITLE
Start script for node-streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log*

--- a/node-streams/package.json
+++ b/node-streams/package.json
@@ -1,10 +1,13 @@
 {
   "name": "streams",
   "version": "0.1.0",
-  "description": "",
+  "description": "A primer on node.js streams ",
   "main": "index.js",
   "author": "Kyle Robinson Young <kyle@dontkry.com> (http://dontkry.com)",
   "license": "MIT",
+  "scripts":{
+ 	"start":"node ./index.js"
+  },
   "devDependencies": {
   }
 }


### PR DESCRIPTION
- `start` script was missing for the `/node-streams` primer
- added `npm-debug.log*` to the root `.gitignore`.

I've taught my students to use `git` to stage steps from your videos, and to be able to use reset to move back and forth between them.  Some of them have committed npm-debug logs to their repos. :smiley: 