### PR TITLE
App Process

### DIFF
--- a/electron-webpack-vuejs/src/main/index.js
+++ b/electron-webpack-vuejs/src/main/index.js
@@ -17,4 +17,8 @@ app.on('ready', () => {
       slashes: true
     }))
   }
+  window.on('closed', function(){
+    window = null
+    app.quit()
+  })
 })


### PR DESCRIPTION
Hi,

I had errors after running "npm run build" the second time after testing the ".exe" file of the application in the dist/win-unpacked folder. I tried to delete the whole project folder to set it up from scratch again but this was not possible. So there was still something running it that folder. Only after restarting my computer i could run "npm run build" again. I wasn't able to find the process in the task manager so i used "Process Explorer". There i saw that the process of the app was still running in the background even the window was closed. After adding the function "window.on('close',.....app.quit()...." the main/index.js file the issue was solved. I don't know if this is a generall problem but on my machine it was. I hope i could help. Im using Windows 10.

By the way thanks for the great tutorial for this framework.

Regards Willy