### PR TITLE
app.quit

### DIFF
--- a/electron-webpack-vuejs/src/main/index.js
+++ b/electron-webpack-vuejs/src/main/index.js
@@ -17,8 +17,13 @@ app.on('ready', () => {
       slashes: true
     }))
   }
-  window.on('closed', function(){
-    window = null
-    app.quit()
+  window.on("closed", () => {
+    window = null;
   })
+})
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
 })


### PR DESCRIPTION
app.quit will now be called when all windows are closed instead by closing only the main window. On macOS the app is not supposed to quit