### PR TITLE
fix: chrome extension error

### DIFF
--- a/how-to-make-chrome-extensions/bear/content.js
+++ b/how-to-make-chrome-extensions/bear/content.js
@@ -6,7 +6,8 @@
 // })
 
 const re = new RegExp('bear', 'gi')
-const matches = document.documentElement.innerHTML.match(re)
+const matches = document.documentElement.innerHTML.match(re) || []
+
 chrome.runtime.sendMessage({
   url: window.location.href,
   count: matches.length


### PR DESCRIPTION
Great tutorial man.

Here's a small fix to handle when there's no search results which errors like below:
![image](https://user-images.githubusercontent.com/9454294/59966826-8fc0a980-9519-11e9-9633-ca3e574dd161.png)
