### PR TITLE
Mac and node fixes

### DIFF
--- a/electron-webpack-vuejs/.gitignore
+++ b/electron-webpack-vuejs/.gitignore
@@ -1,1 +1,3 @@
 dist
+node_modules
+package-lock.json

--- a/electron-webpack-vuejs/package.json
+++ b/electron-webpack-vuejs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "electron-webpack dev",
-    "build": "electron-webpack && electron-builder"
+    "build": "electron-webpack && electron-builder -c.mac.identity=null"
   },
   "author": "Kyle Robinson Young <kyle@dontkry.com> (http://dontkry.com)",
   "license": "MIT",

--- a/electron-webpack-vuejs/src/main/index.js
+++ b/electron-webpack-vuejs/src/main/index.js
@@ -6,7 +6,10 @@ const isDevelopment = process.env.NODE_ENV !== 'production'
 
 app.on('ready', () => {
   let window = new BrowserWindow({
-    width: 1024
+    width: 1024,
+    webPreferences: {
+      nodeIntegration: true
+    }
   })
   if (isDevelopment) {
     window.loadURL(`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}`)


### PR DESCRIPTION
Ignored signing on Mac, which electron-builder now tries to do. It does not work on 10.12.x. Enabled nodeIntegration (now disabled by default in latest version of node).

Nice example by the way. Thanks!